### PR TITLE
document how to resolve 'cblas.h' not found issue in Mac Mojave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ matrex-*.tar
 .tags1
 
 .ipynb_checkpoints
+
+.elixir_ls

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ matrex-*.tar
 .ipynb_checkpoints
 
 .elixir_ls
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ Everything works out of the box, thanks to Accelerate framework. If you encounte
  
 ```native/src/matrix_dot.c:5:10: fatal error: 'cblas.h' file not found``` 
 
-then make sure the XCode command-line tools are installed (`xcode-select --install`)
+then make sure the XCode command-line tools are installed (`xcode-select --install`).
+If the error still not resolved, for MacOS Mojave, run
+```open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg```
+to restore /usr/include and /usr/lib.
 
 ### Ubuntu
 


### PR DESCRIPTION
I am using MacOS Mojave version 10.14.2.
encountered ```'cblas.h' file not found``` error even after running ```xcode-select --install```.
I added a note for how to restore /usr/include and /usr/lib for MacOS Mojave.