### PR TITLE
Only set -lcblas on Linux if MATREX_BLAS==blas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,11 @@ endif
 
 else  # Linux
 	CFLAGS += -shared
-	LDFLAGS += -lm -lcblas
+	LDFLAGS += -lm
 
-ifeq ($(BLAS), openblas)
+ifeq ($(BLAS), blas)
+	LDFLAGS += -lcblas
+else ifeq ($(BLAS), openblas)
 	LDFLAGS += -lopenblas
 else ifeq ($(BLAS), atlas)
 	LDFLAGS += -latlas


### PR DESCRIPTION
Do not set `-lsblas` by default on Linux. This allows to compile Matrex on e.g. Alpine Linux, where only `openblas` is available.