### PR TITLE
Enable cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 
 else ifeq ($(COMPILE_ARCH), linux) # Linux
 	CFLAGS += -shared
-	LDFLAGS += -lm -lcblas
+	LDFLAGS += -lm 
 
 ifeq ($(BLAS), openblas)
 	LDFLAGS += -lopenblas

--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,8 @@ build: $(OBJECTS_DIRECTORIES) $(OBJECTS) $(PRIV_DIRECTORY) $(NIFS_OBJECTS)
 # Target for creating directories for the C object files.
 $(OBJECTS_DIRECTORIES):
 	@mkdir -p $(OBJECTS_DIRECTORIES)
-	echo COMPILE_ARCH: $(COMPILE_ARCH)
-	echo ARCH: $(CC)
-	echo FINDSTR: $(findstring linux,$(CC))
-	echo MATREX_BLAS: $(MATREX_BLAS)
+	@echo 'Compile Arch: '$(COMPILE_ARCH)
+	@echo 'Library BLAS: '$(BLAS)
 
 # Target for creating object files from C source files.
 # Each object file depends on it's corresponding C source file for compilation.

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,21 @@ else ifeq ($(BLAS), noblas)
 	CFLAGS += -D MATREX_NO_BLAS
 endif
 
+# Determine Platform, and check for override $ARCH var
+COMPILE_ARCH=linux
+ifeq ($(shell uname -s), Darwin)
+	COMPILE_ARCH=darwin
+endif
+
+ifeq ($(findstring linux,$(CC)),linux)
+	COMPILE_ARCH=linux
+endif
 
 # MacOS needs extra flags to link successfully
-ifeq ($(shell uname -s), Darwin)
+ifeq ($(COMPILE_ARCH), darwin)
 	LDFLAGS +=  -flat_namespace -undefined suppress
 
+## MacOS BLAS
 ifeq ($(BLAS), openblas)
 	CFLAGS += -I/usr/local/opt/openblas/include
 	LDFLAGS += -L/usr/local/opt/openblas/lib
@@ -46,18 +56,18 @@ else ifeq ($(BLAS), blas)
 	CFLAGS += -I/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers
 endif
 
-else  # Linux
+else ifeq ($(COMPILE_ARCH), linux) # Linux
 	CFLAGS += -shared
-	LDFLAGS += -lm
+	LDFLAGS += -lm -lcblas
 
-ifeq ($(BLAS), blas)
-	LDFLAGS += -lcblas
-else ifeq ($(BLAS), openblas)
+ifeq ($(BLAS), openblas)
 	LDFLAGS += -lopenblas
 else ifeq ($(BLAS), atlas)
 	LDFLAGS += -latlas
 endif
 
+else
+	$(error var was not specified at commandline!)
 endif
 
 # For compiling and linking the test runner.
@@ -167,6 +177,10 @@ build: $(OBJECTS_DIRECTORIES) $(OBJECTS) $(PRIV_DIRECTORY) $(NIFS_OBJECTS)
 # Target for creating directories for the C object files.
 $(OBJECTS_DIRECTORIES):
 	@mkdir -p $(OBJECTS_DIRECTORIES)
+	echo COMPILE_ARCH: $(COMPILE_ARCH)
+	echo ARCH: $(CC)
+	echo FINDSTR: $(findstring linux,$(CC))
+	echo MATREX_BLAS: $(MATREX_BLAS)
 
 # Target for creating object files from C source files.
 # Each object file depends on it's corresponding C source file for compilation.
@@ -286,3 +300,4 @@ ci:
 	@make test
 	@mix coveralls.travis
 	@mix dialyzer --halt-exit-status
+

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,8 @@ defmodule Matrex.MixProject do
       deps: deps(),
       package: package(),
       make_clean: ["clean"],
+      make_env: %{ "MATREX_BLAS" => Application.get_env(:matrex, :blas, System.get_env("MATREX_BLAS")) },
+
       compilers: [:elixir_make] ++ Mix.compilers(),
       aliases: aliases(),
       preferred_cli_env: ["bench.matrex": :bench, docs: :docs],


### PR DESCRIPTION
This changes allows cross compiling. It lets me cross-compile the library for an ARM device. 

Also added a config option to set the MATREX_BLAS makefile variable. Use it by `config :matrex, blas: "noatlas"`, which if unset defaults to using the system variable `$MATREX_BLAS` as before. 
