### PR TITLE
Handle nif loading failure

### DIFF
--- a/lib/matrex/nifs.ex
+++ b/lib/matrex/nifs.ex
@@ -19,7 +19,14 @@ defmodule Matrex.NIFs do
           path
       end
 
-    :ok = :erlang.load_nif(:filename.join(priv_dir, "matrix_nifs"), 0)
+    case :erlang.load_nif(:filename.join(priv_dir, "matrix_nifs"), 0) do
+      :ok ->
+        :ok
+
+      {:error, {:load_failed, reason}} ->
+        IO.warn("Error loading NIF #{reason}")
+        :ok
+    end
   end
 
   @spec add(binary, binary, number, number) :: binary

--- a/lib/matrex/threaded.ex
+++ b/lib/matrex/threaded.ex
@@ -19,7 +19,14 @@ defmodule Matrex.Threaded do
           path
       end
 
-    :ok = :erlang.load_nif(:filename.join(priv_dir, "matrix_threaded_nifs"), 0)
+    case :erlang.load_nif(:filename.join(priv_dir, "matrix_threaded_nifs"), 0) do
+      :ok ->
+        :ok
+
+      {:error, {:load_failed, reason}} ->
+        IO.warn("Error loading NIF #{reason}")
+        :ok
+    end
   end
 
   def apply_math(matrix, function)


### PR DESCRIPTION
When Matrex has a problem loading the NIF, the entire application crashes because of the failed pattern match for `:ok`. 

These changes allow the Erlang VM to start with a warning if the NIF fails to load. Once the application loads, calls to Matrex will then fail in the expected manner:

```
iex(application@127.0.0.1)6> Matrex.random(1000)
** (ErlangError) Erlang error: :nif_library_not_loaded
    :erlang.nif_error(:nif_library_not_loaded)
    (matrex) lib/matrex/nifs.ex:220: Matrex.NIFs.random/2
    (matrex) lib/matrex.ex:1903: Matrex.random/1
```