### PR TITLE
Add lin solve

### DIFF
--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -261,7 +261,7 @@ defmodule Matrex do
             dot_and_add: 3,
             dot_nt: 2,
             dot_tn: 2,
-            solve: 2,
+            forward_substitute: 2,
             cholesky: 1,
             eye: 1,
             element_to_string: 1,
@@ -1182,35 +1182,6 @@ defmodule Matrex do
       do: %Matrex{data: NIFs.dot_tn(first, second, alpha)}
 
   @doc """
-  Matrix solve. NIF, via simple forward substitution.
-
-  The first matrix must be square while the
-  number of columns of the first matrix must
-  equal the number of rows of the second.
-
-  Raises `ErlangError` if matrices' sizes do not match.
-
-  ## Example
-
-      iex> Matrex.solve(
-      ...>   Matrex.new([[3, 4], [4, 8]]) |> Matrex.cholesky(),
-      ...>   Matrex.new([[1],[2]]))
-      #Matrex[2×1]
-      ┌         ┐
-      │ 0.57735 │
-      │ 0.40825 │
-      └         ┘
-
-  """
-  @spec solve(matrex, matrex) :: matrex
-  def solve(
-        matrex_data(rows1, columns1, _data1, first),
-        matrex_data(rows2, columns2, _data2, second)
-      )
-      when rows1 == columns1 and rows1 == rows2 and columns2 == 1,
-      do: %Matrex{data: NIFs.solve(first, second)}
-
-  @doc """
   Matrix cholesky decompose. NIF, via naive implementation.
 
   The first matrix must be symmetric and positive definitive.
@@ -1235,6 +1206,35 @@ defmodule Matrex do
       )
       when rows1 == columns1,
       do: %Matrex{data: NIFs.cholesky(first)}
+
+  @doc """
+  Matrix forward substitution. NIF, via naive C implementation.
+
+  The first matrix must be square while the
+  number of columns of the first matrix must
+  equal the number of rows of the second.
+
+  Raises `ErlangError` if matrices' sizes do not match.
+
+  ## Example
+
+      iex> Matrex.forward_substitute(
+      ...>   Matrex.new([[3, 4], [4, 8]]) |> Matrex.cholesky(),
+      ...>   Matrex.new([[1],[2]]))
+      #Matrex[2×1]
+      ┌         ┐
+      │ 0.57735 │
+      │ 0.40825 │
+      └         ┘
+
+  """
+  @spec forward_substitute(matrex, matrex) :: matrex
+  def forward_substitute(
+        matrex_data(rows1, columns1, _data1, first),
+        matrex_data(rows2, columns2, _data2, second)
+      )
+      when rows1 == columns1 and rows1 == rows2 and columns2 == 1,
+      do: %Matrex{data: NIFs.forward_substitute(first, second)}
 
   @doc """
   Create eye (identity) square matrix of given size.

--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -1190,6 +1190,17 @@ defmodule Matrex do
 
   Raises `ErlangError` if matrices' sizes do not match.
 
+  ## Example
+
+      iex> Matrex.solve(
+      ...>   Matrex.new([[3, 4], [4, 8]]) |> Matrex.cholesky(),
+      ...>   Matrex.new([[1],[2]]))
+      #Matrex[2×1]
+      ┌         ┐
+      │ 0.57735 │
+      │ 0.40825 │
+      └         ┘
+
   """
   @spec solve(matrex, matrex) :: matrex
   def solve(
@@ -1211,16 +1222,12 @@ defmodule Matrex do
       iex> Matrex.new([[3, 4, 3], [4, 8, 6], [3, 6, 9]]) |>
       ...> Matrex.cholesky()
       #Matrex[3×3]
+      ┌                         ┐
+      │ 1.73205     0.0     0.0 │
+      │  2.3094 1.63299     0.0 │
+      │ 1.73205 1.22474 2.12132 │
+      └                         ┘
 
-      ┌                            ┐
-      │   1.73205  2.3094   1.73205  │
-      │   0.0      1.63299  1.22474  │
-      │   0.0      0.0       2.12132  │
-      └                 ┘
-
-       1.73205  2.3094   1.73205
-  0.0       1.63299  1.22474
-  0.0        0.0       2.12132
   """
   @spec cholesky(matrex) :: matrex
   def cholesky(

--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -262,6 +262,7 @@ defmodule Matrex do
             dot_nt: 2,
             dot_tn: 2,
             solve: 2,
+            cholesky: 1,
             eye: 1,
             element_to_string: 1,
             fill: 3,
@@ -1197,6 +1198,21 @@ defmodule Matrex do
       )
       when rows1 == columns1 and rows1 == rows2 and columns2 == 1,
       do: %Matrex{data: NIFs.solve(first, second)}
+
+  @doc """
+  Matrix cholesky decompose. NIF, via naive implementation.
+
+  The first matrix must be square and positive definitive.
+
+  Raises `ErlangError` if matrices' sizes do not match.
+
+  """
+  @spec cholesky(matrex) :: matrex
+  def cholesky(
+        matrex_data(rows1, columns1, _data1, first)
+      )
+      when rows1 == columns1,
+      do: %Matrex{data: NIFs.cholesky(first)}
 
   @doc """
   Create eye (identity) square matrix of given size.

--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -261,6 +261,7 @@ defmodule Matrex do
             dot_and_add: 3,
             dot_nt: 2,
             dot_tn: 2,
+            solve: 2,
             eye: 1,
             element_to_string: 1,
             fill: 3,
@@ -1178,6 +1179,24 @@ defmodule Matrex do
       )
       when rows1 == rows2 and is_number(alpha),
       do: %Matrex{data: NIFs.dot_tn(first, second, alpha)}
+
+  @doc """
+  Matrix solve. NIF, via simple forward substitution.
+
+  The first matrix must be square while the
+  number of columns of the first matrix must
+  equal the number of rows of the second.
+
+  Raises `ErlangError` if matrices' sizes do not match.
+
+  """
+  @spec solve(matrex, matrex) :: matrex
+  def solve(
+        matrex_data(rows1, columns1, _data1, first),
+        matrex_data(rows2, columns2, _data2, second)
+      )
+      when rows1 == columns1 and rows1 == rows2 and columns2 == 1,
+      do: %Matrex{data: NIFs.solve(first, second)}
 
   @doc """
   Create eye (identity) square matrix of given size.

--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -1202,10 +1202,25 @@ defmodule Matrex do
   @doc """
   Matrix cholesky decompose. NIF, via naive implementation.
 
-  The first matrix must be square and positive definitive.
+  The first matrix must be symmetric and positive definitive.
 
   Raises `ErlangError` if matrices' sizes do not match.
 
+  ## Example
+
+      iex> Matrex.new([[3, 4, 3], [4, 8, 6], [3, 6, 9]]) |>
+      ...> Matrex.cholesky()
+      #Matrex[3×3]
+
+      ┌                            ┐
+      │   1.73205  2.3094   1.73205  │
+      │   0.0      1.63299  1.22474  │
+      │   0.0      0.0       2.12132  │
+      └                 ┘
+
+       1.73205  2.3094   1.73205
+  0.0       1.63299  1.22474
+  0.0        0.0       2.12132
   """
   @spec cholesky(matrex) :: matrex
   def cholesky(

--- a/lib/matrex/nifs.ex
+++ b/lib/matrex/nifs.ex
@@ -128,6 +128,11 @@ defmodule Matrex.NIFs do
       when is_binary(first) and is_binary(second) and is_number(alpha),
       do: :erlang.nif_error(:nif_library_not_loaded)
 
+  @spec cholesky(binary) :: binary
+  def cholesky(matrix)
+      when is_binary(matrix),
+      do: :erlang.nif_error(:nif_library_not_loaded)
+
   @spec solve(binary, binary) :: binary
   def solve(matrix, beta)
       when is_binary(matrix) and is_binary(beta),

--- a/lib/matrex/nifs.ex
+++ b/lib/matrex/nifs.ex
@@ -128,8 +128,8 @@ defmodule Matrex.NIFs do
       when is_binary(first) and is_binary(second) and is_number(alpha),
       do: :erlang.nif_error(:nif_library_not_loaded)
 
-  @spec dot_solve(binary, binary) :: binary
-  def dot_solve(matrix, beta)
+  @spec solve(binary, binary) :: binary
+  def solve(matrix, beta)
       when is_binary(matrix) and is_binary(beta),
       do: :erlang.nif_error(:nif_library_not_loaded)
 

--- a/lib/matrex/nifs.ex
+++ b/lib/matrex/nifs.ex
@@ -128,6 +128,11 @@ defmodule Matrex.NIFs do
       when is_binary(first) and is_binary(second) and is_number(alpha),
       do: :erlang.nif_error(:nif_library_not_loaded)
 
+  @spec dot_solve(binary, binary) :: binary
+  def dot_solve(matrix, beta)
+      when is_binary(matrix) and is_binary(beta),
+      do: :erlang.nif_error(:nif_library_not_loaded)
+
   @spec eye(pos_integer, number) :: binary
   def eye(size, value)
       when is_integer(size) and is_number(value),

--- a/lib/matrex/nifs.ex
+++ b/lib/matrex/nifs.ex
@@ -133,8 +133,8 @@ defmodule Matrex.NIFs do
       when is_binary(matrix),
       do: :erlang.nif_error(:nif_library_not_loaded)
 
-  @spec solve(binary, binary) :: binary
-  def solve(matrix, beta)
+  @spec forward_substitute(binary, binary) :: binary
+  def forward_substitute(matrix, beta)
       when is_binary(matrix) and is_binary(beta),
       do: :erlang.nif_error(:nif_library_not_loaded)
 

--- a/native/include/matrix_linalg.h
+++ b/native/include/matrix_linalg.h
@@ -1,0 +1,12 @@
+#ifndef INCLUDED_MATRIX_INV_H
+#define INCLUDED_MATRIX_INV_H
+
+#include "matrix.h"
+
+void
+matrix_decomp_chol(const Matrix matrix, Matrix result);
+
+void
+matrix_solve(const Matrix matrix, const Matrix b, Matrix result);
+
+#endif

--- a/native/include/matrix_linalg.h
+++ b/native/include/matrix_linalg.h
@@ -4,7 +4,7 @@
 #include "matrix.h"
 
 void
-matrix_decomp_chol(const Matrix matrix, Matrix result);
+matrix_cholesky(const Matrix matrix, Matrix result);
 
 void
 matrix_solve(const Matrix matrix, const Matrix b, Matrix result);

--- a/native/nifs/matrix_nifs.c
+++ b/native/nifs/matrix_nifs.c
@@ -483,6 +483,37 @@ dot_tn(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
 }
 
 static ERL_NIF_TERM
+solve(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
+  ErlNifBinary  first, second;
+  ERL_NIF_TERM  result;
+  float        *first_data, *second_data, *result_data;
+  int64_t       data_size;
+  size_t        result_size;
+
+  (void)(argc);
+
+  if (!enif_inspect_binary(env, argv[0], &first )) return enif_make_badarg(env);
+  if (!enif_inspect_binary(env, argv[1], &second)) return enif_make_badarg(env);
+
+  first_data  = (float *) first.data;
+  second_data = (float *) second.data;
+
+  if (MX_COLS(first_data) != MX_COLS(second_data))
+    return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
+  if (MX_ROWS(first_data) != MX_ROWS(second_data))
+    return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
+
+  data_size   =  MX_ROWS(first_data) + 2;
+
+  result_size = sizeof(float) * data_size;
+  result_data = (float *) enif_make_new_binary(env, result_size, &result);
+
+  matrix_solve(first_data, second_data, result_data);
+
+  return result;
+}
+
+static ERL_NIF_TERM
 eye(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
   ERL_NIF_TERM result;
   unsigned long size;

--- a/native/nifs/matrix_nifs.c
+++ b/native/nifs/matrix_nifs.c
@@ -531,7 +531,6 @@ cholesky(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
     return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
 
   data_size   =  MX_ROWS(first_data) * MX_COLS(first_data) + 2;
-
   result_size = sizeof(float) * data_size;
   result_data = (float *) enif_make_new_binary(env, result_size, &result);
 

--- a/native/nifs/matrix_nifs.c
+++ b/native/nifs/matrix_nifs.c
@@ -483,7 +483,7 @@ dot_tn(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
 }
 
 static ERL_NIF_TERM
-solve(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
+forward_substitute(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
   ErlNifBinary  first, second;
   ERL_NIF_TERM  result;
   float        *first_data, *second_data, *result_data;
@@ -1217,7 +1217,7 @@ static ErlNifFunc nif_functions[] = {
   {"dot_nt",               2, dot_nt,               0},
   {"dot_tn",               3, dot_tn,               0},
   {"cholesky",             1, cholesky,             0},
-  {"solve",                2, solve,                0},
+  {"forward_substitute",                2, forward_substitute,                0},
   {"eye",                  2, eye,                  0},
   {"fill",                 3, fill,                 0},
   {"find",                 2, find,                 0},

--- a/native/nifs/matrix_nifs.c
+++ b/native/nifs/matrix_nifs.c
@@ -498,7 +498,7 @@ solve(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
   first_data  = (float *) first.data;
   second_data = (float *) second.data;
 
-  if (MX_COLS(first_data) != MX_COLS(second_data))
+  if (MX_COLS(first_data) != MX_COLS(first_data))
     return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
   if (MX_ROWS(first_data) != MX_ROWS(second_data))
     return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
@@ -1190,6 +1190,7 @@ static ErlNifFunc nif_functions[] = {
   {"dot_and_apply",        3, dot_and_apply,        0},
   {"dot_nt",               2, dot_nt,               0},
   {"dot_tn",               3, dot_tn,               0},
+  {"solve",                2, solve,                0},
   {"eye",                  2, eye,                  0},
   {"fill",                 3, fill,                 0},
   {"find",                 2, find,                 0},

--- a/native/nifs/matrix_nifs.c
+++ b/native/nifs/matrix_nifs.c
@@ -514,6 +514,33 @@ solve(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
 }
 
 static ERL_NIF_TERM
+cholesky(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
+  ErlNifBinary  first;
+  ERL_NIF_TERM  result;
+  float        *first_data, *result_data;
+  int64_t       data_size;
+  size_t        result_size;
+
+  (void)(argc);
+
+  if (!enif_inspect_binary(env, argv[0], &first )) return enif_make_badarg(env);
+
+  first_data  = (float *) first.data;
+
+  if (MX_COLS(first_data) != MX_COLS(first_data))
+    return enif_raise_exception(env, enif_make_string(env, "Matrices sizes mismatch.", ERL_NIF_LATIN1));
+
+  data_size   =  MX_ROWS(first_data) * MX_COLS(first_data) + 2;
+
+  result_size = sizeof(float) * data_size;
+  result_data = (float *) enif_make_new_binary(env, result_size, &result);
+
+  matrix_cholesky(first_data, result_data);
+
+  return result;
+}
+
+static ERL_NIF_TERM
 eye(ErlNifEnv *env, int32_t argc, const ERL_NIF_TERM *argv) {
   ERL_NIF_TERM result;
   unsigned long size;
@@ -1190,6 +1217,7 @@ static ErlNifFunc nif_functions[] = {
   {"dot_and_apply",        3, dot_and_apply,        0},
   {"dot_nt",               2, dot_nt,               0},
   {"dot_tn",               3, dot_tn,               0},
+  {"cholesky",             1, cholesky,             0},
   {"solve",                2, solve,                0},
   {"eye",                  2, eye,                  0},
   {"fill",                 3, fill,                 0},

--- a/native/src/matrix_dot.c
+++ b/native/src/matrix_dot.c
@@ -1,6 +1,6 @@
 #include "../include/matrix.h"
 
-#ifndef MATREX_NO_BLAS
+#ifdef MATREX_NO_BLAS
 
 #include <cblas.h>
 

--- a/native/src/matrix_dot.c
+++ b/native/src/matrix_dot.c
@@ -1,6 +1,6 @@
 #include "../include/matrix.h"
 
-#ifdef MATREX_NO_BLAS
+#ifndef MATREX_NO_BLAS
 
 #include <cblas.h>
 

--- a/native/src/matrix_linalg.c
+++ b/native/src/matrix_linalg.c
@@ -19,8 +19,8 @@ matrix_cholesky(const Matrix matrix, Matrix result) {
   size_t N = MX_ROWS(matrix);
   size_t cols = MX_COLS(matrix);
 
-  for (size_t i = 0; i < data_size; i++)
-    result[i] = 0.0;
+  for (size_t i = 0; i < N*cols; i++)
+    result[2 + i] = 0.0;
 
   MX_SET_ROWS(result, N);
   MX_SET_COLS(result, N);
@@ -28,15 +28,13 @@ matrix_cholesky(const Matrix matrix, Matrix result) {
   for (size_t i = 0; i < N; i++)
       for (size_t k = 0; k < (i+1); k++) {
 
-          float ts = 0;
+          float ts = 0.0;
           for (size_t j = 0; j < k; j++)
             ts += result[2 + i*cols + j] * result[2 + k*cols + j];
 
-          float v = (i == k) ?
-                          sqrt(matrix[2 + i*cols + k] - ts) :
-                          (1.0 / result[2 + k*cols + k] * (result[2 + i*cols + k] - ts));
-
-          result[2 + i*cols + k] = v;
+          result[2 + i*cols + k] = (i == k) ?
+                          sqrt(fmax(matrix[2 + i*cols + i] - ts, 0.0)) :
+                          (1.0 / result[2 + k*cols + k]) * (matrix[2 + i*cols + k] - ts);
       }
 
 }

--- a/native/src/matrix_linalg.c
+++ b/native/src/matrix_linalg.c
@@ -1,25 +1,42 @@
 #include "../include/matrix.h"
 
+/*
 
+S_ik = \sum_{j=1}^{k-1} ( l_ij * l_kj )
+
+if i == k do
+  l_kk = \sqrt{ a_kk - S_ik } 
+else
+  l_ik = \frac{1}{l_kk} \( a_ik - S_ik \)
+end
+
+*/
 
 void
-matrix_decomp_chol(const Matrix matrix, Matrix result) {
+matrix_cholesky(const Matrix matrix, Matrix result) {
   size_t data_size = MX_BYTE_SIZE(matrix);
 
-  memcpy(result, matrix, data_size);
   size_t N = MX_ROWS(matrix);
+  size_t cols = MX_COLS(matrix);
 
-  for (size_t r = 0; r < N; r++)
-      for (size_t c = 0; c < (r+1); c++) {
+  for (size_t i = 0; i < data_size; i++)
+    result[i] = 0.0;
+
+  MX_SET_ROWS(result, N);
+  MX_SET_COLS(result, N);
+
+  for (size_t i = 0; i < N; i++)
+      for (size_t k = 0; k < (i+1); k++) {
+
           float ts = 0;
-          for (size_t k = 0; k < c; k++)
-            ts += result[2 + r*N + k] * result[2 + c*N + k];
+          for (size_t j = 0; j < k; j++)
+            ts += result[2 + i*cols + j] * result[2 + k*cols + j];
 
-          float v = (r == c) ?
-                          sqrt(result[r * N + r] - ts) :
-                          (1.0 / result[c * N + c] * (result[2 + r*N + c] - ts));
+          float v = (i == k) ?
+                          sqrt(matrix[2 + i*cols + k] - ts) :
+                          (1.0 / result[2 + k*cols + k] * (result[2 + i*cols + k] - ts));
 
-          result[2 + r*N + c] = v;
+          result[2 + i*cols + k] = v;
       }
 
 }
@@ -30,7 +47,6 @@ v = zeros(N);
 
 for i in 1:N
     v[i] = ( cK[i] - sum(v .* L[i, :]) ) ./ L[i, i]
-    @show v
 end
 */
 

--- a/native/src/matrix_linalg.c
+++ b/native/src/matrix_linalg.c
@@ -1,0 +1,56 @@
+#include "../include/matrix.h"
+
+
+
+void
+matrix_decomp_chol(const Matrix matrix, Matrix result) {
+  size_t data_size = MX_BYTE_SIZE(matrix);
+
+  memcpy(result, matrix, data_size);
+  size_t N = MX_ROWS(matrix);
+
+  for (size_t r = 0; r < N; r++)
+      for (size_t c = 0; c < (r+1); c++) {
+          float ts = 0;
+          for (size_t k = 0; k < c; k++)
+            ts += result[2 + r*N + k] * result[2 + c*N + k];
+
+          float v = (r == c) ?
+                          sqrt(result[r * N + r] - ts) :
+                          (1.0 / result[c * N + c] * (result[2 + r*N + c] - ts));
+
+          result[2 + r*N + c] = v;
+      }
+
+}
+
+/*
+N = size(L)[1]
+v = zeros(N);
+
+for i in 1:N
+    v[i] = ( cK[i] - sum(v .* L[i, :]) ) ./ L[i, i]
+    @show v
+end
+*/
+
+void
+matrix_solve(const Matrix matrix, const Matrix beta, Matrix result) {
+  const size_t N = MX_ROWS(matrix);
+
+  MX_SET_ROWS(result, N);
+  MX_SET_COLS(result, 1);
+
+  for (size_t i = 0; i < N; i++)
+    result[2 + i] = 0.0;
+
+  for (size_t r = 0; r < N; r++) {
+    // sum(v .* L[i, :])
+    float ts = 0;
+    for (size_t c = 0; c < N; c++)
+      ts += result[2 + r*N + c] * matrix[2 + r*N + c];
+    
+    result[2 + r] = (beta[2 + r] - ts) / matrix[2 + r];
+  }
+
+}

--- a/native/src/matrix_linalg.c
+++ b/native/src/matrix_linalg.c
@@ -37,6 +37,7 @@ end
 void
 matrix_solve(const Matrix matrix, const Matrix beta, Matrix result) {
   const size_t N = MX_ROWS(matrix);
+  const size_t cols = MX_COLS(matrix);
 
   MX_SET_ROWS(result, N);
   MX_SET_COLS(result, 1);
@@ -45,12 +46,13 @@ matrix_solve(const Matrix matrix, const Matrix beta, Matrix result) {
     result[2 + i] = 0.0;
 
   for (size_t r = 0; r < N; r++) {
-    // sum(v .* L[i, :])
-    float ts = 0;
-    for (size_t c = 0; c < N; c++)
-      ts += result[2 + r*N + c] * matrix[2 + r*N + c];
+    const int64_t elem_offset = 2 + r*cols;
+    // sum( v .* L[r,:] )
+    float row_sum = 0.0;
+    for (size_t c = 0; c < r; c++)
+      row_sum += result[2 + c] * matrix[elem_offset + c];
     
-    result[2 + r] = (beta[2 + r] - ts) / matrix[2 + r];
+    result[2 + r] = (beta[2 + r] - row_sum) / matrix[elem_offset + r];
   }
 
 }

--- a/test/matrex_test.exs
+++ b/test/matrex_test.exs
@@ -306,7 +306,7 @@ defmodule MatrexTest do
     end
   end
 
-  test "#solve for `x` where L x = b` where A is of lower triangular form " do
+  test "#forward_substitute for `x` where L x = b` where A is of lower triangular form " do
     first = Matrex.new([
       [0.411927 ,   0.0       ,   0.0       ,   0.0       ,   0.0      ],
       [0.124196 ,  0.392758 ,   0.0       ,   0.0       ,   0.0      ],
@@ -330,7 +330,7 @@ defmodule MatrexTest do
       0.042019689663027514,
     ]]) |> Matrex.transpose()
 
-    result = Matrex.solve(first, second)
+    result = Matrex.forward_substitute(first, second)
 
     assert Matrex.sum(Matrex.subtract(result, expected)) < 1.0e-6
   end

--- a/test/matrex_test.exs
+++ b/test/matrex_test.exs
@@ -335,6 +335,29 @@ defmodule MatrexTest do
     assert Matrex.sum(Matrex.subtract(result, expected)) < 1.0e-6
   end
 
+  test "#decompose cholesky" do
+    first = Matrex.new([
+      [0.169684 ,  0.0511599,  0.0306869,  0.0460945,  0.0488367 ],
+      [0.0511599,  0.169684 ,  0.0476887,  0.0592127,  0.059987  ],
+      [0.0306869,  0.0476887,  0.169684 ,  0.0525878,  0.050069  ],
+      [0.0460945,  0.0592127,  0.0525878,  0.169684 ,  0.0599274 ],
+      [0.0488367,  0.059987 ,  0.050069 ,  0.0599274,  0.169684  ],
+    ])
+
+    expected = Matrex.new([
+      [0.411927, 0.124196,  0.0744958,  0.1119   ,  0.118557 ],
+      [ 0.0    , 0.392758 , 0.0978632,  0.115377 ,  0.115243 ],
+      [ 0.0    ,  0.0     , 0.393137 ,  0.0838399,  0.0762048],
+      [ 0.0    ,  0.0     ,  0.0     ,  0.369894 ,  0.0729279],
+      [ 0.0    ,  0.0     ,  0.0     ,   0.0     ,  0.362245 ],
+    ]) |> Matrex.transpose()
+
+    result = Matrex.cholesky(first)
+    IO.inspect(result, label: :RESULT)
+
+    assert result == expected
+  end
+
   test "#find returns position tuple of the element" do
     matrex = Matrex.reshape(1..100, 10, 10)
     assert Matrex.find(matrex, 11) == {2, 1}

--- a/test/matrex_test.exs
+++ b/test/matrex_test.exs
@@ -349,13 +349,13 @@ defmodule MatrexTest do
       [ 0.0    , 0.392758 , 0.0978632,  0.115377 ,  0.115243 ],
       [ 0.0    ,  0.0     , 0.393137 ,  0.0838399,  0.0762048],
       [ 0.0    ,  0.0     ,  0.0     ,  0.369894 ,  0.0729279],
-      [ 0.0    ,  0.0     ,  0.0     ,   0.0     ,  0.362245 ],
+      [ 0.0    ,  0.0     ,  0.0     ,   0.0     ,  0.362246 ],
     ]) |> Matrex.transpose()
 
     result = Matrex.cholesky(first)
-    IO.inspect(result, label: :RESULT)
+    # IO.inspect(result, label: :RESULT)
 
-    assert result == expected
+    assert Matrex.sum(Matrex.subtract(result, expected)) < 1.0e-6
   end
 
   test "#find returns position tuple of the element" do

--- a/test/matrex_test.exs
+++ b/test/matrex_test.exs
@@ -306,6 +306,35 @@ defmodule MatrexTest do
     end
   end
 
+  test "#solve for `x` where L x = b` where A is of lower triangular form " do
+    first = Matrex.new([
+      [0.411927 ,   0.0       ,   0.0       ,   0.0       ,   0.0      ],
+      [0.124196 ,  0.392758 ,   0.0       ,   0.0       ,   0.0      ],
+      [0.0744958,  0.0978632,  0.393137 ,   0.0       ,   0.0      ],
+      [0.1119   ,  0.115377 ,  0.0838399,  0.369894 ,   0.0      ],
+      [0.118557 ,  0.115243 ,  0.0762048,  0.0729279,  0.362245],
+    ])
+    second = Matrex.new([[
+      0.06006459656788375 ,
+      0.04929101531958022 ,
+      0.028859794242201232,
+      0.0440733627697752  ,
+      0.046876955684785476,
+    ]]) |> Matrex.transpose()
+
+    expected = Matrex.new([[
+      0.1458136653826504,
+      0.0793909826990573,
+      0.026015909233223104,
+      0.044379866911466434,
+      0.042019689663027514,
+    ]]) |> Matrex.transpose()
+
+    result = Matrex.solve(first, second)
+
+    assert Matrex.sum(Matrex.subtract(result, expected)) < 1.0e-6
+  end
+
   test "#find returns position tuple of the element" do
     matrex = Matrex.reshape(1..100, 10, 10)
     assert Matrex.find(matrex, 11) == {2, 1}


### PR DESCRIPTION
This PR includes implementation of  cholesky decomposition and forward substitution functions, `cholesky` and `forward_substitute` respectively. This enables solving a large class linear algebra problems of the `A x = b` form, including least squares efficiently. 

The implementations are naive implementations following the textbook algorithms as closely as possible. It would be possible to call faster LAPACK versions but would require linking LAPACK libraries in addition to CBLAS. Still these implementations provide a stable fallback and should be significantly faster than pure Elixir implementations. 

It would be great to include an `LU` decomposition as well to handle non-positive definite matrices, but my applications don't require generalized `LU` at this time. Though they would be handy to calculate matrix inversions as well. 