### PR TITLE
Fix double negation in docs

### DIFF
--- a/lib/matrex.ex
+++ b/lib/matrex.ex
@@ -2287,7 +2287,7 @@ defmodule Matrex do
   @doc """
   Transfer one-element matrix to a scalar value.
 
-  Differently from `first/1` will not match and throw an error,
+  Unlike `first/1` it raises `FunctionClauseError`
   if matrix contains more than one element.
 
   ## Example


### PR DESCRIPTION
The "Differently from ... will not" made it a bit hard to unwrap the meaning.
I believe changing the "throw" word to "raise" with mentioning the error type also helps.

Thanks for reviewing!

In respect to Matrex I'm in process of writing [Matrax](https://hex.pm/packages/matrax).
Matrax is built on atomics (64 bit integers) for concurrent accessibility.
It has a very different use case compared to Matrex so they cannot really be interchanged / compared but from a matrix functionality standpoint I'm having a much easier time thanks to Matrex's documentation. Thank you!

:wave:   