### PR TITLE
Permanently archived the exlearn repository at new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, vectorized linear regression is about 13 times faster, than Octave 
 It's also memory efficient, so you can work with large matrices,
 about billion of elements in size.
 
-Based on matrix code from https://github.com/sdwolfz/exlearn
+Based on matrix code from https://gitlab.com/sdwolfz/experimental/-/tree/master/exlearn
 
 ## Benchmarks
 


### PR DESCRIPTION
Hello, sorry to bother you with this trivial matter.

Following GitHub's betrayal, I've permanently archived the `exlearn` repository at this location... 

- https://gitlab.com/sdwolfz/experimental/-/tree/master/exlearn 

...so I've updated the README to point there instead of the current broken link.